### PR TITLE
2020 initial setting

### DIFF
--- a/conf/pycon-tw.conf
+++ b/conf/pycon-tw.conf
@@ -1,0 +1,4 @@
+server {
+    server_name pycon.tw;
+    return 302 https://tw.pycon.org$request_uri;
+}

--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -27,6 +27,10 @@ upstream pycontw-2019 {
     server pycontw-2019:8000;
 }
 
+upstream pycontw-2020 {
+    server pycontw-2020:8000;
+}
+
 server {
     listen 80 default_server;
     server_name tw.pycon.org localhost;
@@ -105,6 +109,15 @@ server {
 
     location ~ ^/2019 {
         proxy_pass http://pycontw-2019;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-Port $server_port;
+        proxy_set_header X-Real-Scheme $scheme;
+    }
+
+    location ~ ^/2020 {
+        proxy_pass http://pycontw-2020;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;


### PR DESCRIPTION
Add 2020 routing for this year's conference. And also add a rule to redirect from `pycon.tw' to `tw.pycon.org' in order to avoid 400 Bad Request problems.