### PR TITLE
feat: set `client_max_body_size` to 10M

### DIFF
--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -39,6 +39,7 @@ server {
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;
 
+    client_max_body_size 10M;
 
     # http redirect to https
     if ($http_x_forwarded_proto = "http") {


### PR DESCRIPTION
## feat: set `client_max_body_size` to 10M

## WHY

Need to setup the max body size in case users upload files that are too large. This change is done on the production machine since Apr. 2020 but has not been checked in after the modification.

## HOW

see the doc: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size