### PR TITLE
chore(conf): add config for serving 2021 website 

### DIFF
--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -31,6 +31,10 @@ upstream pycontw-2020 {
     server pycontw-2020:8000;
 }
 
+upstream pycontw-2021 {
+    server pycontw-2021:8000;
+}
+
 server {
     listen 80 default_server;
     server_name tw.pycon.org localhost;
@@ -120,6 +124,15 @@ server {
 
     location ~ ^/2020 {
         proxy_pass http://pycontw-2020;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-Port $server_port;
+        proxy_set_header X-Real-Scheme $scheme;
+    }
+
+    location ~ ^/2021 {
+        proxy_pass http://pycontw-2021;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;


### PR DESCRIPTION
The deployment of the 2021 website will be ready after [pycon.tw/#971](https://github.com/pycontw/pycon.tw/pull/971) is merged. The purpose of this PR is to enable `pycontw-nginx` also serves the 2021 website on the GCE.