### PR TITLE
feat: serve 2021 frontend

### DIFF
--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -61,6 +61,7 @@ server {
 
     # Default path
     rewrite "^/$" /2021 redirect;
+    rewrite "^(/(en-us|zh-hant)(/.*)?)$" /2021$1 redirect;
 
     location ~ ^/(2012|2013|site_media) {
         proxy_pass http://pycontw-2012-2013;

--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -60,7 +60,7 @@ server {
     }
 
     # Default path
-    # rewrite "^/$" /latest redirect;
+    rewrite "^/$" /2021 redirect;
 
     location ~ ^/(2012|2013|site_media) {
         proxy_pass http://pycontw-2012-2013;
@@ -135,7 +135,7 @@ server {
         proxy_set_header X-Real-Scheme $scheme;
     }
 
-    location ~ ^/2021 {
+    location ~ ^/prs {
         proxy_pass http://pycontw-2021;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
@@ -144,7 +144,7 @@ server {
         proxy_set_header X-Real-Scheme $scheme;
     }
 
-    location ~ ^/ {
+    location ~ ^/2021 {
         proxy_pass http://pycontw-2021-frontend;
         proxy_set_header X-Real-IP  $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -35,6 +35,10 @@ upstream pycontw-2021 {
     server pycontw-2021:8000;
 }
 
+upstream pycontw-2021-frontend {
+    server pycontw-2021-frontend:3000;
+}
+
 server {
     listen 80 default_server;
     server_name tw.pycon.org localhost;
@@ -56,7 +60,7 @@ server {
     }
 
     # Default path
-    rewrite "^/$" /latest redirect;
+    # rewrite "^/$" /latest redirect;
 
     location ~ ^/(2012|2013|site_media) {
         proxy_pass http://pycontw-2012-2013;
@@ -140,19 +144,13 @@ server {
         proxy_set_header X-Real-Scheme $scheme;
     }
 
-    location /latest {
-        rewrite . /pycon2021/index.html last;
-    }
-
-    location /pycon2021 {
-        proxy_pass https://storage.googleapis.com/pycon2021;
+    location ~ ^/ {
+        proxy_pass http://pycontw-2021-frontend;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host storage.googleapis.com;
-    }
-
-    location /landing-page-2021 {
-        rewrite "landing-page-2021(.*)" /pycon2021$1 last;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-Port $server_port;
+        proxy_set_header X-Real-Scheme $scheme;
     }
 
 }


### PR DESCRIPTION
serve 2021 frontend & retire 2021 landing page

## Mar. 31, 2021 update

In the late Feb. of 2021, we change the endpoint of the website from `tw.pycon.org/2021/` to `tw.pycon.org/` but later want to change the endpoints of frontend & backend as follow:

- frontend: tw.pycon.org/ -> tw.pycon.org/2021
- backend: tw.pycon.org/2021 -> tw.pycon.org/prs


Related PRs:
- [pycontw-2021/#23](https://github.com/pycontw/pycontw-2021/pull/23)
- [pycon.tw#997](https://github.com/pycontw/pycon.tw/pull/997)