### PR TITLE
chore: proxy requests (16-20 website) to archive version on gh-page

### DIFF
--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -41,6 +41,7 @@ server {
     # Default path
     rewrite "^/$" /2021 redirect;
     rewrite "^(/(en-us|zh-hant)(/.*)?)$" /2021$1 redirect;
+    rewrite "^/(2016|2017|2018|2019|2020)/$" /$1/en-us/ redirect;
 
     set $index_name "index.html";
 

--- a/conf/tw-pycon-org.conf
+++ b/conf/tw-pycon-org.conf
@@ -6,29 +6,8 @@ upstream pycontw-2014apac {
     server pycontw-2014apac;
 }
 
-
 upstream pycontw-2015apac {
     server pycontw-2015apac;
-}
-
-upstream pycontw-2016 {
-    server pycontw-2016:8000;
-}
-
-upstream pycontw-2017 {
-    server pycontw-2017:8000;
-}
-
-upstream pycontw-2018 {
-    server pycontw-2018:8000;
-}
-
-upstream pycontw-2019 {
-    server pycontw-2019:8000;
-}
-
-upstream pycontw-2020 {
-    server pycontw-2020:8000;
 }
 
 upstream pycontw-2021 {
@@ -63,6 +42,8 @@ server {
     rewrite "^/$" /2021 redirect;
     rewrite "^(/(en-us|zh-hant)(/.*)?)$" /2021$1 redirect;
 
+    set $index_name "index.html";
+
     location ~ ^/(2012|2013|site_media) {
         proxy_pass http://pycontw-2012-2013;
         proxy_set_header X-Real-IP  $remote_addr;
@@ -91,49 +72,44 @@ server {
         proxy_set_header X-Real-Scheme $scheme;
     }
 
-    location ~ ^/2016 {
-        proxy_pass http://pycontw-2016;
+    location /2016 {
+        rewrite /$ $uri$index_name;
+        proxy_pass https://pycontw.github.io/pycon_archive_past_website/2016;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-Port $server_port;
-        proxy_set_header X-Real-Scheme $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host pycontw.github.io;
     }
-
-    location ~ ^/2017 {
-        proxy_pass http://pycontw-2017;
+    
+    location /2017 {
+        rewrite /$ $uri$index_name;
+        proxy_pass https://pycontw.github.io/pycon_archive_past_website/2017;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-Port $server_port;
-        proxy_set_header X-Real-Scheme $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host pycontw.github.io;
     }
-
-    location ~ ^/2018 {
-        proxy_pass http://pycontw-2018;
+    
+    location /2018 {
+        rewrite /$ $uri$index_name;
+        proxy_pass https://pycontw.github.io/pycon_archive_past_website/2018;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-Port $server_port;
-        proxy_set_header X-Real-Scheme $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host pycontw.github.io;
     }
-
-    location ~ ^/2019 {
-        proxy_pass http://pycontw-2019;
+    
+    location /2019 {
+        rewrite /$ $uri$index_name;
+        proxy_pass https://pycontw.github.io/pycon_archive_past_website/2019;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-Port $server_port;
-        proxy_set_header X-Real-Scheme $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host pycontw.github.io;
     }
-
-    location ~ ^/2020 {
-        proxy_pass http://pycontw-2020;
+    
+    location /2020 {
+        rewrite /$ $uri$index_name;
+        proxy_pass https://pycontw.github.io/pycon_archive_past_website/2020;
         proxy_set_header X-Real-IP  $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-Port $server_port;
-        proxy_set_header X-Real-Scheme $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host pycontw.github.io;
     }
 
     location ~ ^/prs {


### PR DESCRIPTION
Archiving the historical websites (and stop running their servers) are wanted. We have archived version of 2016-2020 websites in [pycontw/pycon_archive_past_website](https://github.com/pycontw/pycon_archive_past_website) now. Need to modify the nginx config to proxy the requests to github pages.