### PR TITLE
fix(deploy): adopt new docker network for 2022 website

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 
@@ -11,8 +11,12 @@ services:
     hostname: pycontw-nginx
     volumes:
         - /var/www/letsencrypt:/var/www/letsencrypt
+    networks:
+        - pycontw-net
+        - network-2022
 
 networks:
-    default:
-        external:
-            name: pycontw-net
+    pycontw-net:
+        external: true
+    network-2022:
+        external: true


### PR DESCRIPTION
## WHY

The website of PyCon TW 2021 began malfunctioning after the website of 2022 deploying to production. The behaviors include (1) round-robin 404 and (2) randomly failing to download static files. We've checked all the configs of the frontend app and reassured the hostnames are correct, but still cannot find out the reason. 

## HOW

The root cause is still unknown but isolating the docker network used by the containers of the 2022 website makes the 2021 website back to normal again. 

## Related PRs

- https://github.com/pycontw/pycon.tw/pull/1074
- https://github.com/pycontw/pycontw-frontend/pull/222
- https://github.com/pycontw/pycontw-nginx/pull/11
- https://github.com/pycontw/pycontw-postgresql/pull/1