### PR TITLE
fix: block random subdomain

### DIFF
--- a/conf/prod/tw-pycon-org.conf
+++ b/conf/prod/tw-pycon-org.conf
@@ -6,14 +6,23 @@ upstream pycontw-2024-frontend {
     server pycontw-2024-frontend:3000;
 }
 
+# Default server block to handle unmatched subdomains
 server {
-    # redirect www.tw.pycon.org to tw.pycon.org
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 404;
+}
+
+# Redirect www.tw.pycon.org to tw.pycon.org
+server {
+    listen 80;
     server_name www.tw.pycon.org;
     return 301 $scheme://tw.pycon.org$request_uri;
 }
 
 server {
-    listen 80 default_server;
+    listen 80;
     server_name tw.pycon.org;
     charset utf-8;
 
@@ -159,5 +168,4 @@ server {
         proxy_set_header X-Real-Port $server_port;
         proxy_set_header X-Real-Scheme $scheme;
     }
-
 }


### PR DESCRIPTION
## why

anyone can access the production site from `https://insert.whatever.you.want.tw.pycon.org/`, which is not expected.

## how

return 404 if it does not match the server name